### PR TITLE
feat: add hideEmpty prop to prevent rendering empty cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ link-prevue have the following props for customize the component
 **cardWidth**         | _String_   | no       | _'400px'_                                | Card width, accept `px` and `%`
 **showButton**        | _Boolean_  | no       | _true_                                   | Render card button
 **apiUrl**            | _String_   | no       | _https://link-preview-api.nivaldo.workers.dev/preview_ | Custom API url, link-preview add a query param called ?url= [check this](https://github.com/nivaldomartinez/link-prevue-api-node)
+**hideWhenEmpty**     | _Boolean_  | no       | _false_                                   | Hide card when image, title, and description are all null in the API response
 
 
 ## API REST

--- a/src/LinkPrevue.vue
+++ b/src/LinkPrevue.vue
@@ -5,7 +5,7 @@
         <div class="spinner"></div>
       </slot>
     </div>
-    <div v-if="response">
+    <div v-if="response && shouldShowCard">
       <slot :img="response.image" :title="response.title" :description="response.description" :url="url">
         <div class="wrapper" :style="{ width: cardWidth }">
           <div class="card-img">
@@ -46,6 +46,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    hideWhenEmpty: {
+      type: Boolean,
+      default: false,
+    },
     apiUrl: {
       type: String,
       default: "https://link-preview-api.nivaldo.workers.dev/preview",
@@ -66,6 +70,14 @@ export default {
       validUrl: false,
     };
   },
+  computed: {
+    shouldShowCard: function () {
+      if (!this.response) return false;
+      if (!this.hideWhenEmpty) return true;
+
+      return this.response.image !== null || this.response.title !== null || this.response.description !== null;
+    },
+  },
   methods: {
     viewMore: function () {
       if (this.onButtonClick !== undefined) {
@@ -84,6 +96,15 @@ export default {
       if (this.isValidUrl(this.url)) {
         this.httpRequest(
           (response) => {
+            if (
+              this.hideEmpty &&
+              (!response.title && !response.description && !response.image)
+            ) {
+              this.response = null;
+              this.validUrl = false;
+              return;
+            }
+
             this.response = response;
           },
           () => {


### PR DESCRIPTION
This PR adds a new `hideWhenEmpty` prop that prevents the component from rendering an empty card when the link preview API returns missing or incomplete data.
If `hideWhenEmpty` is set to `true` and the response contains no title, description, or image, the component now returns `null` instead of displaying an empty placeholder.

Fixes #71.

Demo: 
<img width="1918" height="866" alt="image" src="https://github.com/user-attachments/assets/37517ae7-18cb-4f92-b024-4c10fe317661" />
