### PR TITLE
feat: Add showButtonWhileLoading prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ To use a custom loading indicator, use the loading slot.
 </div>
 ```
 
+## Show button while loading
+
+When loading data for multiple links takes time, you can show a button during the loading state that allows users to visit the link immediately. The button only requires the URL which is already provided as a component property.
+
+```html
+<div id="app">
+  <LinkPrevue url="https://vuejs.org/" :showButtonWhileLoading="true"></LinkPrevue>
+</div>
+```
+
+This is particularly useful when:
+- Loading multiple link previews simultaneously
+- Network requests are slow
+- You want to provide users with immediate access to the link while preview data loads
+
 ## Custom button handler
 
 For custom button handler use the onButtonClick property, like.
@@ -102,13 +117,15 @@ export default {
 
 link-prevue have the following props for customize the component
 
- Prop                 | Type       | Required | Default Value                            | Description
---------------------- | ---------- | -------- | ---------------------------------------- | -----------
-**url**               | _String_   | yes      | _undefined_                              | Site url for generate link preview
-**onButtonClick**     | _Function_ | no       | _undefined_                              | Function for a custom button handler, params => `prevue`
-**cardWidth**         | _String_   | no       | _'400px'_                                | Card width, accept `px` and `%`
-**showButton**        | _Boolean_  | no       | _true_                                   | Render card button
-**apiUrl**            | _String_   | no       | _https://link-preview-api.nivaldo.workers.dev/preview_ | Custom API url, link-preview add a query param called ?url= [check this](https://github.com/nivaldomartinez/link-prevue-api-node)
+ Prop                     | Type       | Required | Default Value                            | Description
+------------------------- | ---------- | -------- | ---------------------------------------- | -----------
+**url**                   | _String_   | yes      | _undefined_                              | Site url for generate link preview
+**onButtonClick**         | _Function_ | no       | _undefined_                              | Function for a custom button handler, params => `prevue`
+**cardWidth**             | _String_   | no       | _'400px'_                                | Card width, accept `px` and `%`
+**showButton**            | _Boolean_  | no       | _true_                                   | Render card button
+**showButtonWhileLoading** | _Boolean_  | no       | _false_                                  | Show a button during loading state that opens the URL. Useful when loading multiple links takes time.
+**landscape**             | _Boolean_  | no       | _false_                                  | Enable landscape card layout (less height, more width). Automatically reverts to vertical on mobile screens (≤640px)
+**apiUrl**                | _String_   | no       | _https://link-preview-api.nivaldo.workers.dev/preview_ | Custom API url, link-preview add a query param called ?url= [check this](https://github.com/nivaldomartinez/link-prevue-api-node)
 **hideWhenEmpty**     | _Boolean_  | no       | _false_                                   | Hide card when image, title, and description are all null in the API response
 
 

--- a/src/LinkPrevue.vue
+++ b/src/LinkPrevue.vue
@@ -2,7 +2,12 @@
   <div>
     <div id="loader-container" v-if="!response && validUrl" :style="{ width: cardWidth }">
       <slot name="loading">
-        <div class="spinner"></div>
+        <div class="loading-content">
+          <div class="spinner"></div>
+          <div class="loading-btn" v-if="showButtonWhileLoading">
+            <a href="javascript:;" @click="viewMore">Visit Link</a>
+          </div>
+        </div>
       </slot>
     </div>
     <div v-if="response && shouldShowCard">
@@ -45,6 +50,10 @@ export default {
     showButton: {
       type: Boolean,
       default: true,
+    },
+    showButtonWhileLoading: {
+      type: Boolean,
+      default: false,
     },
     hideWhenEmpty: {
       type: Boolean,
@@ -207,15 +216,51 @@ img {
 }
 
 /* Loader */
+.loading-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2em 0;
+  min-height: 200px;
+}
+
 .spinner {
-  margin-top: 40%;
-  margin-left: 45%;
   height: 28px;
   width: 28px;
   animation: rotate 0.8s infinite linear;
   border: 5px solid #868686;
   border-right-color: transparent;
   border-radius: 50%;
+  margin-bottom: 1.5em;
+}
+
+.loading-btn {
+  margin-top: 1em;
+  text-align: center;
+}
+
+.loading-btn a {
+  border-radius: 2em;
+  font-family: "Hind Siliguri", sans-serif;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: #ffffff;
+  background-color: #ffa9be;
+  padding: 10px 20px 10px 20px;
+  text-align: center;
+  display: inline-block;
+  text-decoration: none !important;
+  -webkit-transition: all 0.2s ease-in-out;
+  -moz-transition: all 0.2s ease-in-out;
+  -ms-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  cursor: pointer;
+}
+
+.loading-btn a:hover {
+  background-color: #ff8fab;
 }
 
 @keyframes rotate {


### PR DESCRIPTION
Added a new `showButtonWhileLoading` prop to display a "Visit Link" button during the loading state, allowing users to access links immediately while preview data is being fetched.

## Changes
- Added `showButtonWhileLoading` prop (default: `false`)
- Displays "Visit Link" button below spinner when enabled
- Button opens URL in new tab
- Professional styling matching existing design system
- Updated demo page and documentation (Replace app's code with [demo_app.txt](https://github.com/user-attachments/files/23940797/demo_app.txt)'s code)

## Usage
```
<LinkPrevue url="https://vuejs.org/" :showButtonWhileLoading="true" />
```
**Note:** This feature is particularly useful when loading multiple link previews simultaneously, as it provides users with immediate access to links even while preview data is still loading. The button only requires the URL which is already available as a component property.
Fixed: #41 
-
<img width="1295" height="416" alt="image" src="https://github.com/user-attachments/assets/3444d78b-91b7-4894-8a59-35717362eb0d" />
